### PR TITLE
GPU: Improve unnecessary return value in Map function. (#1799)

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -115,8 +115,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="pa">CPU virtual address to map into</param>
         /// <param name="va">GPU virtual address to be mapped</param>
         /// <param name="size">Size in bytes of the mapping</param>
-        /// <returns>GPU virtual address of the mapping</returns>
-        public ulong Map(ulong pa, ulong va, ulong size)
+        public void Map(ulong pa, ulong va, ulong size)
         {
             lock (_pageTable)
             {
@@ -127,8 +126,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     SetPte(va + offset, pa + offset);
                 }
             }
-
-            return va;
         }
 
         /// <summary>

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
@@ -253,7 +253,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
                         if (va != NvMemoryAllocator.PteUnmapped && va <= uint.MaxValue && (va + (uint)map.Size) <= uint.MaxValue)
                         {
                             _memoryAllocator.AllocateRange(va, (uint)map.Size, freeAddressStartPosition);
-                            map.DmaMapAddress = (long)gmm.Map((ulong)map.Address, va, (uint)map.Size);
+                            gmm.Map((ulong)map.Address, va, (uint)map.Size);
+                            map.DmaMapAddress = (long)va;
                         }
                         else
                         {


### PR DESCRIPTION
* Implement VFNMA.F<32/64>

* Update PTC Version

* Update Implementation & Renames & Correct Order

* Add Logging

* Additional logging

* Add additional check to restart loop from beginning if address goes beyond maximum allowed.

* Additional Check that the total range required doesn't exceed capacity of allocator addresses.

* Improve logging

* Ensure hex output

* Update Ryujinx.HLE/HOS/Services/Nv/NvMemoryAllocator.cs

Co-authored-by: gdkchan <gab.dark.100@gmail.com>

* Remove extra page at end

* Remove unnecessary return val in Map function.

* Remove incorrect description

Co-authored-by: gdkchan <gab.dark.100@gmail.com>